### PR TITLE
Fix block explorer links

### DIFF
--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -133,7 +133,7 @@ export const VerificationResult = ({ files }) => (
                       style={{ fontFamily: "monospace" }}
                       rel="nofollow noopener noreferrer"
                       target="_blank"
-                      href={`https://testnet.dcrdata.org/tx/${transaction}`}
+                      href={`https://explorer.dcrdata.org/tx/${transaction}`}
                     >
                       {transaction}
                     </Link>

--- a/src/helpers/format.js
+++ b/src/helpers/format.js
@@ -1,7 +1,7 @@
 export const formatDigestToDownload = ({name, transaction, date, result}) => {
     return JSON.stringify({
         "file": name,
-        "transaction": `https://testnet.dcrdata.org/tx/${transaction}`,
+        "transaction": `https://explorer.dcrdata.org/tx/${transaction}`,
         "achoredDate": date,
         "fullResult": result,
     });


### PR DESCRIPTION
Authit is creating invalid links to the testnet explorer with mainnet transactions.